### PR TITLE
React 17/18 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ export const onClientEntry = () => {
 > __*Note*:__
 > 
 >  You can register multiple decorators with multiple `registerDecorator` statements.
+
+# Version Notes
+Package version 3.0 and up support React/React-Dom 17.0.1 and up.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-react-decorators",
-  "version": "2.0.0-beta.2",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,7 @@
   },
   "peerDependencies": {
     "gatsby": "^3.0.0 || ^4.0.0",
-    "webpack-decorators": "^0.0.4"
+    "webpack-decorators": "^0.0.4",
+    "react-dom": "^17.0.1"
   }
 }

--- a/src/react-dom/webpackConfigFactory.js
+++ b/src/react-dom/webpackConfigFactory.js
@@ -1,18 +1,11 @@
 exports.getWebpackConfig = function (useProfiler, aliases) {
     const reactDomPath = useProfiler ? `gatsby-plugin-react-decorators/src/react-dom/profiling/react-dom-profiler` : `webpack-decorators-react-dom`;
-    const schedulerPath = useProfiler ? `scheduler/tracing-profiling` : 'scheduler/tracing';
-
-    aliases = {
-      'scheduler/tracing': schedulerPath,
-      ...aliases
-    };
     const resolveAlias = (module, defaultPath) => aliases[module] ?? defaultPath ?? module;
 
     return {
       resolve: {
         alias: {
           "react-dom$": require.resolve(reactDomPath),
-          "scheduler/tracing": require.resolve(resolveAlias(`scheduler/tracing`)),
           "___react-dom-original___$": require.resolve(resolveAlias(`react-dom`)),
         },
       }


### PR DESCRIPTION
Adding support for React/React-Dom 17.0.1 (and up), which changes the API of 'scheduler' to remove 'tracing' file path.